### PR TITLE
Update package api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,30 +5,32 @@ const parser = require('./parser');
 const { data2cap, data2jupyter } = require('./templates/index');
 
 module.exports = {
-  html2notebook: (userConfig) => {
-
-    if (!userConfig.inputFile) {
-      throw new Error('ERROR: Missing HTML input file. Nothing to convert.');
-    }
-
-    const notebookData = getNotebookData(parser(userConfig));
-
-    let notebook;
-    switch(userConfig.type) {
-      case "cap":
-        notebook = data2cap(notebookData);
-        break;
-      case "jupyter":
-        notebook = data2jupyter(notebookData);
-        break;
-    }
-
-    const notebookString = JSON.stringify(notebook, null, 4);
-    if (userConfig.outputFile) {
-      fs.writeFileSync(userConfig.outputFile, notebookString, 'utf8');
-    } else {
-      process.stdout.write(`${notebookString}\n`);
-    }
-
-  }
+  html2data,
+  data2notebook,
+  html2notebook: (userConfig) => data2notebook(html2data(userConfig))
 };
+
+function html2data(userConfig) {
+  if (!userConfig.inputFile) {
+    throw new Error('ERROR: Missing HTML input file. Nothing to convert.');
+  }
+  return getNotebookData(parser(userConfig));
+}
+
+function data2notebook(notebookData) {
+  let notebook;
+  switch(userConfig.type) {
+    case "cap":
+      notebook = data2cap(notebookData);
+      break;
+    case "jupyter":
+      notebook = data2jupyter(notebookData);
+      break;
+  }
+  if (userConfig.outputFile) {
+    fs.writeFileSync(userConfig.outputFile, JSON.stringify(notebook, null, 4), 'utf8');
+    console.log(`INFO: Notebook written to file "${userConfig.outputFile}"`);
+    return
+  }
+  return notebook;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const { data2cap, data2jupyter } = require('./templates/index');
 module.exports = {
   html2data,
   data2notebook,
-  html2notebook: (userConfig) => data2notebook(html2data(userConfig))
+  html2notebook: (userConfig) => data2notebook(userConfig, html2data(userConfig))
 };
 
 function html2data(userConfig) {
@@ -17,7 +17,7 @@ function html2data(userConfig) {
   return getNotebookData(parser(userConfig));
 }
 
-function data2notebook(notebookData) {
+function data2notebook(userConfig, notebookData) {
   let notebook;
   switch(userConfig.type) {
     case "cap":


### PR DESCRIPTION
- Offer `html2data()` and `data2notebook` separately, in case the user would like to add a filter or some other type of post-processing of the (generic) notebook data
- `html2notebook()` is offered for all use cases where no further customisation or post-processing steps are necessary